### PR TITLE
Update mixer_midi.js to detect 01v96v2

### DIFF
--- a/server/modules/mixer_midi.js
+++ b/server/modules/mixer_midi.js
@@ -13,7 +13,7 @@
     i;
 
 var matchPortName = function(name) {
-    return (name.toLowerCase().indexOf('yamaha 01v96') !== -1 || name.match(/01V96 ..:0/i));
+    return (name.toLowerCase().indexOf('01v96') !== -1 || name.match(/01V96 ..:0/i));
 };
 
 var transmitMessage = function(deltaTime, message) {


### PR DESCRIPTION
Hello, I had issues with conencting to my 01v96v2.
As it turns out, the _midi_ library only detects it like this:
`[mixer_midi] MIDI input port 2 / 01V96:01V96 MIDI 1 28:0`
`[mixer_midi] MIDI output port 2 / 01V96:01V96 MIDI 1 28:0`
so I modded the detect phrase accordingly.
I still have some issues - ON/OFF button does not work, but that'll have to wait.